### PR TITLE
fix(cron): Miscalculation for dates and end of months

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   pull_request:
-    - main
+    branches:
+      - main
   push:
-    - main
+    branches:
+      - main
 
 jobs:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
   push:
+    - main
 
 jobs:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
   push:
-    branches:
-      - main
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    - main
   push:
     - main
 

--- a/src/clj_cron_parse/core.clj
+++ b/src/clj_cron_parse/core.clj
@@ -371,11 +371,11 @@
    (when-let [result (when-let [{:keys [dom dow] :as cron-map} (make-cron-map cron)]
                        (match [dom dow]
                          [:star :star] (next-date-by-dom now cron-map)
-                         [_ :star] (next-date-by-dom now cron-map)
-                         [:star _] (next-date-by-dow now cron-map)
-                         :else (let [by-dom (next-date-by-dom now cron-map)
-                                     by-dow (next-date-by-dow now cron-map)]
-                                 (-> [by-dom by-dow] sort first))))]
+                         [_ :star]     (next-date-by-dom now cron-map)
+                         [:star _]     (next-date-by-dow now cron-map)
+                         :else         (let [by-dom (next-date-by-dom now cron-map)
+                                             by-dow (next-date-by-dow now cron-map)]
+                                         (-> [by-dom by-dow] sort first))))]
      (assert (not (t/before? result now))
              (format "Next cron resulted in a timestamp that was before the provided timestamp, schedule: %s relative to: %s result: %s" cron now result))
      result))

--- a/src/clj_cron_parse/core.clj
+++ b/src/clj_cron_parse/core.clj
@@ -233,7 +233,17 @@
     :W (next-week-dom now)
     ([& xs] :seq) (if-let [ns (next-val (t/day now) xs)]
                     (t/plus now (t/days (- ns (t/day now))))
-                    (t/plus now (t/months 1) (t/days (- (first xs) (t/day now)))))
+                    ;; Takes the current timestamp, adds the next month
+                    (let [month (t/plus now (t/months 1))]
+                      (t/max-date
+                       ;; If the calculated next recurrence is before the first
+                       ;; day of the next month then we are definitely wrong.
+                       ;; Instead calculate the next recurrence relative to the
+                       ;; first day of the next month instead of the current
+                       ;; timestamp
+                       (t/plus now (t/months 1) (t/days (- (first xs) (t/day now))))
+                       ;; WOOOOOOOOOO RECURSION
+                       (now-with-doms (t/first-day-of-the-month (t/year month) (t/month month)) dom))))
     {:range x} (t/plus now (t/days 1))
     :else now))
 

--- a/src/clj_cron_parse/core.clj
+++ b/src/clj_cron_parse/core.clj
@@ -242,8 +242,10 @@
                        ;; first day of the next month instead of the current
                        ;; timestamp
                        (t/plus now (t/months 1) (t/days (- (first xs) (t/day now))))
+                       ;; If our next from above is before the start of the
+                       ;; month then use the start of the next month as the
+                       ;; relative timestamp.
                        ;; WOOOOOOOOOO RECURSION
-
                        (now-with-doms (t/date-time (t/year month)
                                                    (t/month month)
                                                    (t/day month)

--- a/src/clj_cron_parse/core.clj
+++ b/src/clj_cron_parse/core.clj
@@ -251,7 +251,8 @@
                                                    (t/day month)
                                                    (t/hour now)
                                                    (t/minute now)
-                                                   (t/second now)) dom))))
+                                                   (t/second now))
+                                      dom))))
     {:range x} (t/plus now (t/days 1))
     :else now))
 

--- a/test/clj_cron_parse/core_test.clj
+++ b/test/clj_cron_parse/core_test.clj
@@ -1,7 +1,9 @@
 (ns clj-cron-parse.core-test
-  (:require [clj-cron-parse.core :refer :all]
-            [midje.sweet :refer :all]
-            [clj-time.core :as t]))
+  (:require
+   [clj-cron-parse.core :refer :all]
+   [clj-time.core :as t]
+   [clojure.test :refer [deftest is testing]]
+   [midje.sweet :refer :all]))
 
 (defchecker date [& date-args]
   (checker [actual]
@@ -132,3 +134,7 @@
 (facts "should handle short month weirdness"
        (next-date (t/date-time 2020 3 30) "0 0 0 1 * *") => (date 2020 04 01 00 00 000)
        (next-date (t/date-time 2020 1 30) "0 0 0 1 * *") => (date 2020 02 01 00 00 000))
+
+(deftest weirdness
+  (testing "real observed issue"
+    (is (= (t/date-time 2025 02 01) (next-date (t/date-time 2025 1 30) "0 12 4 1,2,4 * *")))))

--- a/test/clj_cron_parse/core_test.clj
+++ b/test/clj_cron_parse/core_test.clj
@@ -143,4 +143,9 @@
     (is (= (t/date-time 2025 01 29 05 02 00) (next-date (t/date-time 2025 1 28 05 02 00) "0 2 5 * * *")))
     (is (= (t/date-time 2025 02 01 04 12 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 1,2,4 * *")))
     (is (= (t/date-time 2025 02 01 04 12 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 1,2,4 * *")))
-    (is (= (t/date-time 2025 02 02 04 12 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 2,4 * *")))))
+    (is (= (t/date-time 2025 02 02 04 12 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 2,4 * *")))
+
+    (is (= (t/date-time 2025 03 02 04 12 00) (next-date (t/date-time 2025 2 28 03 00 00) "0 12 4 2,4 * *")))
+    (is (= (t/date-time 2025 04 02 04 12 00) (next-date (t/date-time 2025 3 30 03 00 00) "0 12 4 2,4 * *")))
+
+    (is (= (t/date-time 2025 04 02 04 12 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 2,4 4 *")))))

--- a/test/clj_cron_parse/core_test.clj
+++ b/test/clj_cron_parse/core_test.clj
@@ -138,5 +138,9 @@
 (deftest weirdness
   (testing "real observed issue"
     (is (= (t/date-time 2025 01 28 05 02 00) (next-date (t/date-time 2025 1 28 05 00 00) "0 2 5 * * *")))
-    (is (= (t/date-time 2025 02 01 00 00 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 1,2,4 * *")))
-    (is (= (t/date-time 2025 02 02 00 00 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 2,4 * *")))))
+    ; ;; When we are at the exact timestamp of the cron, we should schedule for
+    ; ;; the NEXT instance.
+    (is (= (t/date-time 2025 01 29 05 02 00) (next-date (t/date-time 2025 1 28 05 02 00) "0 2 5 * * *")))
+    (is (= (t/date-time 2025 02 01 04 12 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 1,2,4 * *")))
+    (is (= (t/date-time 2025 02 01 04 12 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 1,2,4 * *")))
+    (is (= (t/date-time 2025 02 02 04 12 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 2,4 * *")))))

--- a/test/clj_cron_parse/core_test.clj
+++ b/test/clj_cron_parse/core_test.clj
@@ -137,4 +137,6 @@
 
 (deftest weirdness
   (testing "real observed issue"
-    (is (= (t/date-time 2025 02 01) (next-date (t/date-time 2025 1 30) "0 12 4 1,2,4 * *")))))
+    (is (= (t/date-time 2025 01 28 05 02 00) (next-date (t/date-time 2025 1 28 05 00 00) "0 2 5 * * *")))
+    (is (= (t/date-time 2025 02 01 00 00 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 1,2,4 * *")))
+    (is (= (t/date-time 2025 02 02 00 00 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 2,4 * *")))))

--- a/test/clj_cron_parse/core_test.clj
+++ b/test/clj_cron_parse/core_test.clj
@@ -128,3 +128,7 @@
        (next-date now "1 0 12 * * *" "Asia/Seoul") => (date 2015 01 02 03 00 01 000)
        (next-date (t/date-time 2015 01 01 12 00 02) "1 0 12 * * *" "America/Sao_Paulo") => (date 2015 01 01 14 00 01 000)
        (next-date (t/date-time 2015 01 01 12 00 02) "1 * * * * *" "America/Sao_Paulo") => (t/date-time 2015 01 01 12 01 01))
+
+(facts "should handle short month weirdness"
+       (next-date (t/date-time 2020 3 30) "0 0 0 1 * *") => (date 2020 04 01 00 00 000)
+       (next-date (t/date-time 2020 1 30) "0 0 0 1 * *") => (date 2020 02 01 00 00 000))


### PR DESCRIPTION
Taken from https://github.com/finity-ai/clj-cron-parse/issues/2

Trying to address bug in not returning the correct dates for the next
run.
