### PR TITLE
(ENG-2808) Fixing bug where timestamp could be in the past

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,4 +46,4 @@ jobs:
         run: lein test
 
       - name: Legacy stuff
-        run: lein do clean, midje, cljfmt check
+        run: lein do clean, cljfmt check

--- a/project.clj
+++ b/project.clj
@@ -7,8 +7,6 @@
                  [clj-time "0.15.2"]
                  [org.clojure/core.match "1.0.0"]]
   :pedantic? :abort
-  :profiles {:dev {:dependencies [[midje "1.10.5"]]
-                   :plugins [[lein-cljfmt "0.8.0"]
-                             [lein-midje "3.2.2"]]}}
+  :profiles {:dev {:plugins [[lein-cljfmt "0.8.0"]]}}
   :repositories [["github" {:url "https://maven.pkg.github.com/treasuryprime/com.treasuryprime.clj-cron-parse"
                             :username "treasuryprime"}]])

--- a/src/com/treasuryprime/clj_cron_parse/core.clj
+++ b/src/com/treasuryprime/clj_cron_parse/core.clj
@@ -370,18 +370,26 @@
   ([now cron]
    (when-let [result (when-let [{:keys [dom dow] :as cron-map} (make-cron-map cron)]
                        (match [dom dow]
+                         ;; This one
                          [:star :star] (next-date-by-dom now cron-map)
                          [_ :star]     (next-date-by-dom now cron-map)
                          [:star _]     (next-date-by-dow now cron-map)
                          :else         (let [by-dom (next-date-by-dom now cron-map)
                                              by-dow (next-date-by-dow now cron-map)]
                                          (-> [by-dom by-dow] sort first))))]
-     (assert (not (t/before? result now))
-             (format "Next cron resulted in a timestamp that was before the provided timestamp, schedule: %s relative to: %s result: %s" cron now result))
-     result))
-
+     (if (t/before? result now)
+       (next-date result cron nil true)
+       result)))
   ([now cron timezone]
    (if timezone
      (let [tz-now (t/to-time-zone now (t/time-zone-for-id timezone))]
        (t/to-time-zone (next-date tz-now cron) (t/time-zone-for-id "UTC")))
-     (next-date now cron))))
+     (next-date now cron)))
+  ([now cron timezone nested]
+   (let [result (next-date now cron timezone)]
+     (if (t/after? result now)
+       result
+       (do
+         (assert (not nested) (format "Next cron resulted in a timestamp that was before the provided timestamp, schedule: %s relative to: %s result: %s" cron now result))
+         (next-date result cron timezone true))))))
+

--- a/src/com/treasuryprime/clj_cron_parse/core.clj
+++ b/src/com/treasuryprime/clj_cron_parse/core.clj
@@ -370,7 +370,6 @@
   ([now cron]
    (when-let [result (when-let [{:keys [dom dow] :as cron-map} (make-cron-map cron)]
                        (match [dom dow]
-                         ;; This one
                          [:star :star] (next-date-by-dom now cron-map)
                          [_ :star]     (next-date-by-dom now cron-map)
                          [:star _]     (next-date-by-dow now cron-map)

--- a/test/com/treasuryprime/clj_cron_parse/core_test.clj
+++ b/test/com/treasuryprime/clj_cron_parse/core_test.clj
@@ -1,142 +1,138 @@
 (ns com.treasuryprime.clj-cron-parse.core-test
   (:require
-   [com.treasuryprime.clj-cron-parse.core :refer :all]
    [clj-time.core :as t]
    [clojure.test :refer [deftest is testing]]
-   [midje.sweet :refer :all]))
-
-(defchecker date [& date-args]
-  (checker [actual]
-           (let [d (apply t/date-time date-args)]
-             (= d actual))))
+   [com.treasuryprime.clj-cron-parse.core :refer [next-date]]))
 
 (def now (t/date-time 2015 01 01 12 00 00 000))
 (def nye (t/date-time 2014 12 31 12 00 00 000))
 
-(time (facts "should find next date for cron expression"
-             (next-date now "1 * * * * *") => (date 2015 01 01 12 00 01 000)
-             (next-date (t/date-time 2022 05 24 10 59 00) "0 */5 * * * *") => (t/date-time 2022 05 24 11 00 00)
-             (next-date now "* 1 * * * *") => (date 2015 01 01 12 01 00 000)
-             (next-date now "* * 13 * * *") => (date 2015 01 01 13 00 00 000)
-             (next-date now "* * * 10 * *") => (date 2015 01 10 12 00 00 000)
-             (next-date now "* * * * 2 *") => (date 2015 02 01 12 00 00 000)
-             (next-date now "11 12 13 14 10 *") => (date 2015 10 14 13 12 11 000)
-             (next-date now "* * * * * 0") => (date 2015 01 04 12 00 00 000)
-             (next-date now "* * * * * 3") => (date 2015 01 07 12 00 00 000)
-             (next-date nye "* * 10 * * *") => (date 2015 01 01 10 00 00 000)
-             (next-date now "1,2 * * * * *") => (date 2015 01 01 12 00 01 000)
-             (next-date now "1-20 * * * * *") => (date 2015 01 01 12 00 01 000)
-             (next-date now "*/2 * * * * *") => (date 2015 01 01 12 00 02 000)
-             (next-date now "1-20/2 * * * * *") => (date 2015 01 01 12 00 01 000)
-             (next-date (t/date-time 2015 01 01 12 00 04 000) "3-20/2 * * * * *") => (date 2015 01 01 12 00 05 000)
-             (next-date now "* 1,2 * * * *") => (date 2015 01 01 12 01 00 000)
-             (next-date now "* */2 * * * *") => (date 2015 01 01 12 00 00 000)
-             (next-date now "* 1-20 * * * *") => (date 2015 01 01 12 01 00 000)
-             (next-date now "* 1-20/2 * * * *") => (date 2015 01 01 12 01 00 000)
-             (next-date (t/date-time 2015 01 01 12 05 00 000) "* 1-20/3 * * * *") => (date 2015 01 01 12 07 00 000)
-             (next-date now "* * 1,2 * * *") => (date 2015 01 02 01 00 00 000)
-             (next-date (t/date-time 2015 01 01 13 00 00 000) "* * */2 * * *") => (date 2015 01 01 14 00 00 000)
-             (next-date (t/date-time 2015 01 01 21 00 00 000) "* * 1-20 * * *") => (date 2015 01 02 01 00 00 000)
-             (next-date now "* * 1-20/2 * * *") => (date 2015 01 01 13 00 00 000)
-             (next-date now "* * 11 1,2 * *") => (date 2015 01 02 11 00 00 000)
-             (next-date now "* * * */2 * *") => (date 2015 01 02 12 00 00 000)
-             (next-date now "* * 11 1-20 * *") => (date 2015 01 02 11 00 00 000)
-             (next-date now "* * 11 1-20/2 * *") => (date 2015 01 03 11 00 00 000)
-             (next-date now "* * * L * *") => (date 2015 01 31 12 00 00 000)
-             (next-date now "* * * W * *") => (date 2015 01 02 12 00 00 000)
-             (next-date (t/date-time 2015 01 02 12 00 00 000) "* * * W * *") => (date 2015 01 05 12 00 00 000)
-             (next-date now "* * * * FEB *") => (date 2015 02 01 12 00 00 000)
-             (next-date now "* * * * feb *") => (date 2015 02 01 12 00 00 000)
-             (next-date now "* * * * 2 *") => (date 2015 02 01 12 00 00 000)
-             (next-date now "* * * * 2,3 *") => (date 2015 02 01 12 00 00 000)
-             (next-date now "* * * * */2 *") => (date 2015 02 01 12 00 00 000)
-             (next-date now "* * * * 2-11 *") => (date 2015 02 01 12 00 00 000)
-             (next-date now "* * * * 2-11/3 *") => (date 2015 02 01 12 00 00 000)
-             (next-date (t/date-time 2015 03 01 12 00 00 000) "* * * * 1-11/3 *") => (date 2015 04 01 12 00 00 000)
-             (next-date now "* * * * * 1,2") => (date 2015 01 05 12 00 00 000)
-             (next-date now "* * 11 * * 1-5") => (date 2015 01 02 11 00 00 000)
-             (next-date now "* * 11 * * W") => (date 2015 01 02 11 00 00 000)
-             (next-date now "* * * * * MON") => (date 2015 01 05 12 00 00 000)
-             (next-date now "* * * * * mon") => (date 2015 01 05 12 00 00 000)
-             (next-date now "* * * * * */2") => (date 2015 01 02 12 00 00 000)
-       ;(next-date now "* * * * * 1-5/2") => (bit of an edge case I think)
-             (next-date now "* * * * * 1L") => (date 2015 01 26 12 00 00 000)
-             (next-date now "* * * * * 1L,2L") => (date 2015 01 26 12 00 00 000)
-             (next-date now "* * * * * 2L") => (date 2015 01 27 12 00 00 000)
-             (next-date now "* * * * * 3L") => (date 2015 01 28 12 00 00 000)
-             (next-date now "* * * * * 4L") => (date 2015 01 29 12 00 00 000)
-             (next-date now "* * * * * 5L") => (date 2015 01 30 12 00 00 000)
-             (next-date now "* * * * * 6L") => (date 2015 01 31 12 00 00 000)
-             (next-date now "* * * * * 7L") => (date 2015 01 25 12 00 00 000)
-             (next-date now "* * * * * 6L,7L") => (date 2015 01 25 12 00 00 000)
-             (next-date (t/date-time 2015 01 02 12 00 00 000) "* * 11 * * 1-5") => (date 2015 01 05 11 00 00 000)
-             (next-date (t/date-time 2015 01 02 12 00 00 000) "* * 11 * * W") => (date 2015 01 05 11 00 00 000)
-             (next-date now "@yearly") => (date 2016 01 01 00 00 00 000)
-             (next-date now "@annually") => (date 2016 01 01 00 00 00 000)
-             (next-date now "@monthly") => (date 2015 02 01 00 00 00 000)
-             (next-date now "@weekly") => (date 2015 01 05 00 00 00 000)
-             (next-date now "@daily") => (date 2015 01 02 00 00 00 000)
-             (next-date now "@midnight") => (date 2015 01 02 00 00 00 000)
-             (next-date now "@hourly") => (date 2015 01 01 13 00 00 000)
-             (next-date (t/date-time 2015 04 22 06 22 29 000) "30 22 6 * * 3") => (date 2015 04 22 06 22 30 000)
-             (next-date (t/date-time 2015 04 21 06 22 30 000) "30 22 6 * * 3") => (date 2015 04 22 06 22 30 000)))
+(deftest dates-test
+  (testing "should find next date for cron expression"
+    (is (= (t/date-time 2015 01 01 12 00 01) (next-date now "1 * * * * *")))
+    (is (= (t/date-time 2022 05 24 11 00 00) (next-date (t/date-time 2022 05 24 10 59 00) "0 */5 * * * *")))
+    (is (= (t/date-time 2015 01 01 12 01 00) (next-date now "* 1 * * * *")))
+    (is (= (t/date-time 2015 01 01 13 00 00) (next-date now "* * 13 * * *")))
+    (is (= (t/date-time 2015 01 10 12 00 00) (next-date now "* * * 10 * *")))
+    (is (= (t/date-time 2015 02 01 12 00 00) (next-date now "* * * * 2 *")))
+    (is (= (t/date-time 2015 10 14 13 12 11) (next-date now "11 12 13 14 10 *")))
+    (is (= (t/date-time 2015 01 04 12 00 00) (next-date now "* * * * * 0")))
+    (is (= (t/date-time 2015 01 07 12 00 00) (next-date now "* * * * * 3")))
+    (is (= (t/date-time 2015 01 01 10 00 00) (next-date nye "* * 10 * * *")))
+    (is (= (t/date-time 2015 01 01 12 00 01) (next-date now "1,2 * * * * *")))
+    (is (= (t/date-time 2015 01 01 12 00 01) (next-date now "1-20 * * * * *")))
+    (is (= (t/date-time 2015 01 01 12 00 02) (next-date now "*/2 * * * * *")))
+    (is (= (t/date-time 2015 01 01 12 00 01) (next-date now "1-20/2 * * * * *")))
+    (is (= (t/date-time 2015 01 01 12 00 05) (next-date (t/date-time 2015 01 01 12 00 04) "3-20/2 * * * * *")))
+    (is (= (t/date-time 2015 01 01 12 01 00) (next-date now "* 1,2 * * * *")))
+    (is (= (t/date-time 2015 01 01 12 00 00) (next-date now "* */2 * * * *")))
+    (is (= (t/date-time 2015 01 01 12 01 00) (next-date now "* 1-20 * * * *")))
+    (is (= (t/date-time 2015 01 01 12 01 00) (next-date now "* 1-20/2 * * * *")))
+    (is (= (t/date-time 2015 01 01 12 07 00) (next-date (t/date-time 2015 01 01 12 05 00) "* 1-20/3 * * * *")))
+    (is (= (t/date-time 2015 01 02 01 00 00) (next-date now "* * 1,2 * * *")))
+    (is (= (t/date-time 2015 01 01 14 00 00) (next-date (t/date-time 2015 01 01 13 00 00) "* * */2 * * *")))
+    (is (= (t/date-time 2015 01 02 01 00 00) (next-date (t/date-time 2015 01 01 21 00 00) "* * 1-20 * * *")))
+    (is (= (t/date-time 2015 01 01 13 00 00) (next-date now "* * 1-20/2 * * *")))
+    (is (= (t/date-time 2015 01 02 11 00 00) (next-date now "* * 11 1,2 * *")))
+    (is (= (t/date-time 2015 01 02 12 00 00) (next-date now "* * * */2 * *")))
+    (is (= (t/date-time 2015 01 02 11 00 00) (next-date now "* * 11 1-20 * *")))
+    (is (= (t/date-time 2015 01 03 11 00 00) (next-date now "* * 11 1-20/2 * *")))
+    (is (= (t/date-time 2015 01 31 12 00 00) (next-date now "* * * L * *")))
+    (is (= (t/date-time 2015 01 02 12 00 00) (next-date now "* * * W * *")))
+    (is (= (t/date-time 2015 01 05 12 00 00) (next-date (t/date-time 2015 01 02 12 00 00) "* * * W * *")))
+    (is (= (t/date-time 2015 02 01 12 00 00) (next-date now "* * * * FEB *")))
+    (is (= (t/date-time 2015 02 01 12 00 00) (next-date now "* * * * feb *")))
+    (is (= (t/date-time 2015 02 01 12 00 00) (next-date now "* * * * 2 *")))
+    (is (= (t/date-time 2015 02 01 12 00 00) (next-date now "* * * * 2,3 *")))
+    (is (= (t/date-time 2015 02 01 12 00 00) (next-date now "* * * * */2 *")))
+    (is (= (t/date-time 2015 02 01 12 00 00) (next-date now "* * * * 2-11 *")))
+    (is (= (t/date-time 2015 02 01 12 00 00) (next-date now "* * * * 2-11/3 *")))
+    (is (= (t/date-time 2015 04 01 12 00 00) (next-date (t/date-time 2015 03 01 12 00 00) "* * * * 1-11/3 *")))
+    (is (= (t/date-time 2015 01 05 12 00 00) (next-date now "* * * * * 1,2")))
+    (is (= (t/date-time 2015 01 02 11 00 00) (next-date now "* * 11 * * 1-5")))
+    (is (= (t/date-time 2015 01 02 11 00 00) (next-date now "* * 11 * * W")))
+    (is (= (t/date-time 2015 01 05 12 00 00) (next-date now "* * * * * MON")))
+    (is (= (t/date-time 2015 01 05 12 00 00) (next-date now "* * * * * mon")))
+    (is (= (t/date-time 2015 01 02 12 00 00) (next-date now "* * * * * */2")))
+    ;(next-date now "* * * * * 1-5/2") => (bit of an edge case I think)
+    (is (= (t/date-time 2015 01 26 12 00 00) (next-date now "* * * * * 1L")))
+    (is (= (t/date-time 2015 01 26 12 00 00) (next-date now "* * * * * 1L,2L")))
+    (is (= (t/date-time 2015 01 27 12 00 00) (next-date now "* * * * * 2L")))
+    (is (= (t/date-time 2015 01 28 12 00 00) (next-date now "* * * * * 3L")))
+    (is (= (t/date-time 2015 01 29 12 00 00) (next-date now "* * * * * 4L")))
+    (is (= (t/date-time 2015 01 30 12 00 00) (next-date now "* * * * * 5L")))
+    (is (= (t/date-time 2015 01 31 12 00 00) (next-date now "* * * * * 6L")))
+    (is (= (t/date-time 2015 01 25 12 00 00) (next-date now "* * * * * 7L")))
+    (is (= (t/date-time 2015 01 25 12 00 00) (next-date now "* * * * * 6L,7L")))
+    (is (= (t/date-time 2015 01 05 11 00 00) (next-date (t/date-time 2015 01 02 12 00 00) "* * 11 * * 1-5")))
+    (is (= (t/date-time 2015 01 05 11 00 00) (next-date (t/date-time 2015 01 02 12 00 00) "* * 11 * * W")))
+    (is (= (t/date-time 2016 01 01 00 00 00) (next-date now "@yearly")))
+    (is (= (t/date-time 2016 01 01 00 00 00) (next-date now "@annually")))
+    (is (= (t/date-time 2015 02 01 00 00 00) (next-date now "@monthly")))
+    (is (= (t/date-time 2015 01 05 00 00 00) (next-date now "@weekly")))
+    (is (= (t/date-time 2015 01 02 00 00 00) (next-date now "@daily")))
+    (is (= (t/date-time 2015 01 02 00 00 00) (next-date now "@midnight")))
+    (is (= (t/date-time 2015 01 01 13 00 00) (next-date now "@hourly")))
+    (is (= (t/date-time 2015 04 22 06 22 30) (next-date (t/date-time 2015 04 22 06 22 29) "30 22 6 * * 3")))
+    (is (= (t/date-time 2015 04 22 06 22 30) (next-date (t/date-time 2015 04 21 06 22 30) "30 22 6 * * 3")))))
 
 ;; TODO: close to new year, combinations, range/n for dow
 
-(facts "should return nil for an invalid cron expression"
-       (next-date now "x * * * * *") => nil
-       (next-date now "* x * * * *") => nil
-       (next-date now "* * x * * *") => nil
-       (next-date now "* * * x * *") => nil
-       (next-date now "* * * * x *") => nil
-       (next-date now "* * * * * x") => nil
-       (next-date now "L * * * * *") => nil
-       (next-date now "* L * * * *") => nil
-       (next-date now "* * L * * *") => nil
-       (next-date now "* * * 1L * *") => nil
-       (next-date now "* * * * L *") => nil
-       (next-date now "* * * * * L") => nil
-       (next-date now "W * * * * *") => nil
-       (next-date now "* W * * * *") => nil
-       (next-date now "* * W * * *") => nil
-       (next-date now "* * * * W *") => nil
-       (next-date now "61 * * * * *") => nil
-       (next-date now "* 61 * * * *") => nil
-       (next-date now "* * 25 * * *") => nil
-       (next-date now "* * * 32 * *") => nil
-       (next-date now "* * * * 13 *") => nil
-       (next-date now "* * * * * * *") => nil
-       (next-date now "1,62 * * * * *") => nil
-       (next-date now "* 1,62 * * * *") => nil
-       (next-date now "* * 1,25 * * *") => nil
-       (next-date now "* * * 1,32 * *") => nil
-       (next-date now "* * * * 2,13 *") => nil
-       (next-date now "* * * * * 1,8") => nil
-       (next-date now "1-62 * * * * *") => nil
-       (next-date now "* 1-62 * * * *") => nil
-       (next-date now "* * 1-25 * * *") => nil
-       (next-date now "* * * 1-32 * *") => nil
-       (next-date now "* * * * 2-13 *") => nil
-       (next-date now "* * * * * 1-8") => nil
-       (next-date now "* * * * * 8L") => nil
-       (next-date now "* * * * febx *") => nil
-       (next-date now "* * * * * MONx") => nil
-       (next-date now "s s") => nil
-       (next-date now "") => nil)
+(deftest return-nil-test
+  (testing "should return nil for an invalid cron expression"
+    (is (nil? (next-date now "x * * * * *")))
+    (is (nil? (next-date now "* x * * * *")))
+    (is (nil? (next-date now "* * x * * *")))
+    (is (nil? (next-date now "* * * x * *")))
+    (is (nil? (next-date now "* * * * x *")))
+    (is (nil? (next-date now "* * * * * x")))
+    (is (nil? (next-date now "L * * * * *")))
+    (is (nil? (next-date now "* L * * * *")))
+    (is (nil? (next-date now "* * L * * *")))
+    (is (nil? (next-date now "* * * 1L * *")))
+    (is (nil? (next-date now "* * * * L *")))
+    (is (nil? (next-date now "* * * * * L")))
+    (is (nil? (next-date now "W * * * * *")))
+    (is (nil? (next-date now "* W * * * *")))
+    (is (nil? (next-date now "* * W * * *")))
+    (is (nil? (next-date now "* * * * W *")))
+    (is (nil? (next-date now "61 * * * * *")))
+    (is (nil? (next-date now "* 61 * * * *")))
+    (is (nil? (next-date now "* * 25 * * *")))
+    (is (nil? (next-date now "* * * 32 * *")))
+    (is (nil? (next-date now "* * * * 13 *")))
+    (is (nil? (next-date now "* * * * * * *")))
+    (is (nil? (next-date now "1,62 * * * * *")))
+    (is (nil? (next-date now "* 1,62 * * * *")))
+    (is (nil? (next-date now "* * 1,25 * * *")))
+    (is (nil? (next-date now "* * * 1,32 * *")))
+    (is (nil? (next-date now "* * * * 2,13 *")))
+    (is (nil? (next-date now "* * * * * 1,8")))
+    (is (nil? (next-date now "1-62 * * * * *")))
+    (is (nil? (next-date now "* 1-62 * * * *")))
+    (is (nil? (next-date now "* * 1-25 * * *")))
+    (is (nil? (next-date now "* * * 1-32 * *")))
+    (is (nil? (next-date now "* * * * 2-13 *")))
+    (is (nil? (next-date now "* * * * * 1-8")))
+    (is (nil? (next-date now "* * * * * 8L")))
+    (is (nil? (next-date now "* * * * febx *")))
+    (is (nil? (next-date now "* * * * * MONx")))
+    (is (nil? (next-date now "s s")))
+    (is (nil? (next-date now "")))))
 
-(facts "should provide next date calculated within a timezone"
-       (next-date now "1 0 12 * * *" nil) => (date 2015 01 01 12 00 01 000)
-       (next-date now "1 0 12 * * *" "UTC") => (date 2015 01 01 12 00 01 000)
-       (next-date now "1 0 12 * * *" "Asia/Seoul") => (date 2015 01 02 03 00 01 000)
-       (next-date (t/date-time 2015 01 01 12 00 02) "1 0 12 * * *" "America/Sao_Paulo") => (date 2015 01 01 14 00 01 000)
-       (next-date (t/date-time 2015 01 01 12 00 02) "1 * * * * *" "America/Sao_Paulo") => (t/date-time 2015 01 01 12 01 01))
+(deftest timezone-next-date-test
+  (testing "should provide next date calculated within a timezone"
+    (is (= (t/date-time 2015 01 01 12 00 01) (next-date now "1 0 12 * * *" nil)))
+    (is (= (t/date-time 2015 01 01 12 00 01) (next-date now "1 0 12 * * *" "UTC")))
+    (is (= (t/date-time 2015 01 02 03 00 01) (next-date now "1 0 12 * * *" "Asia/Seoul")))
+    (is (= (t/date-time 2015 01 01 14 00 01) (next-date (t/date-time 2015 01 01 12 00 02) "1 0 12 * * *" "America/Sao_Paulo")))
+    (is (= (t/date-time 2015 01 01 12 01 01) (next-date (t/date-time 2015 01 01 12 00 02) "1 * * * * *" "America/Sao_Paulo")))))
 
-(facts "should handle short month weirdness"
-       (next-date (t/date-time 2020 3 30) "0 0 0 1 * *") => (date 2020 04 01 00 00 000)
-       (next-date (t/date-time 2020 1 30) "0 0 0 1 * *") => (date 2020 02 01 00 00 000))
+(deftest short-month-bug
+  (testing "should handle crons at the end of a month where the next month is shorter"
+    (is (= (t/date-time 2020 04 01 00 00) (next-date (t/date-time 2020 3 30) "0 0 0 1 * *")))
+    (is (= (t/date-time 2020 02 01 00 00) (next-date (t/date-time 2020 1 30) "0 0 0 1 * *")))
 
-(deftest weirdness
-  (testing "real observed issue"
     (is (= (t/date-time 2025 01 28 05 02 00) (next-date (t/date-time 2025 1 28 05 00 00) "0 2 5 * * *")))
     ; ;; When we are at the exact timestamp of the cron, we should schedule for
     ; ;; the NEXT instance.
@@ -149,3 +145,8 @@
     (is (= (t/date-time 2025 04 02 04 12 00) (next-date (t/date-time 2025 3 30 03 00 00) "0 12 4 2,4 * *")))
 
     (is (= (t/date-time 2025 04 02 04 12 00) (next-date (t/date-time 2025 1 30 03 00 00) "0 12 4 2,4 4 *")))))
+
+(deftest always-future-test
+  (testing "should always generate a timestamp after the provided timestamp"
+    (is (= (t/date-time 2025 02 19 11 20 00)
+           (next-date (t/date-time 2025 02 19 11 15 59) "0 */5 * * * *")))))


### PR DESCRIPTION
There was an issue where the cron library could return a timestamp that
was in the past relative to now, this would cause a cron job to be run
multiple times depending on when the cron job timestamp was evaluated.

This is because the cron library does not handle time drifting at all,
if a cron spec is evaluated a few seconds after a valid timestamp then
it will return the previous valid timestamp as it rounds down first. The
way this is now avoided is that if the timestamp returned from the cron
library is in the past relative to the initially provided timestamp,
then the cron spec is _re-evaluated_ using the resulting past timestamp.
This will produce a correct future timestamp.
